### PR TITLE
fix(ci): Add explicit packages:write permission

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,6 +7,9 @@ on:
   push:
     branches:
       - main
+permissions:
+  contents: read
+  packages: write
 env:
   IMAGE: "ghcr.io/${{ github.repository }}"
   PLATFORMS: "linux/amd64,linux/arm64"


### PR DESCRIPTION
A change to the GitHub organization-level policy controls made the default GITHUB_TOKEN no longer have package write access. This change should restore that and allow the build to succeed.